### PR TITLE
[#64785440] Add support for https backend

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -364,7 +364,8 @@ Worker.prototype.runServer = function (config) {
                 var proxy = new httpProxy.HttpProxy({
                     target: {
                         host: backend.hostname,
-                        port: backend.port
+                        port: backend.port,
+                        https: backend.protocol == 'https:'
                     },
                     enable: {
                         xforward: false
@@ -398,7 +399,8 @@ Worker.prototype.runServer = function (config) {
             proxy = new httpProxy.HttpProxy({
                 target: {
                     host: backend.hostname,
-                    port: backend.port
+                    port: backend.port,
+                    https: backend.protocol == 'https:'
                 }
             });
             proxy.proxyWebSocketRequest(req, socket, head, buffer);


### PR DESCRIPTION
node-http-proxy already supports https as a backend, but hipache isn't configured as such.

Tagging @doomspork for review
