### PR TITLE
[#64844520] Add backend host header support

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -190,8 +190,10 @@ Cache.prototype.getBackendFromHostHeader = function (host, callback) {
         if (backends.length === 0) {
             return callback('frontend not found', 400);
         }
+
         var virtualHost = backends[0];
         backends = backends.slice(1); // copy to not modify the lru in place
+
         var index = (function () {
             // Pickup a random backend index
             var indexes = [];
@@ -206,13 +208,24 @@ Cache.prototype.getBackendFromHostHeader = function (host, callback) {
             }
             return indexes[Math.floor(Math.random() * indexes.length)];
         }());
+
         if (index < 0) {
             return callback('Cannot find a valid backend', 502);
         }
         var backend = url.parse(backends[index]);
         backend.id = index; // Store the backend index
+
+        var hostHeader = host;
         backend.frontend = host; // Store the associated frontend
+
+        var host_index = virtualHost.indexOf('|');
+        if (host_index > 0) {
+            hostHeader = virtualHost.slice(host_index + 1).toLowerCase();
+            virtualHost = virtualHost.slice(0, host_index);
+        }
+        backend.hostHeader = hostHeader;
         backend.virtualHost = virtualHost; // Store the associated vhost
+
         backend.len = backends.length;
         if (backend.hostname === undefined) {
             return callback('backend is invalid', 502);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -150,6 +150,9 @@ Worker.prototype.runServer = function (config) {
             // FIXME: replace by the real port instead of hardcoding it
             req.headers['x-forwarded-port'] = req.connection.pair ? '443' : '80';
         }
+        if (req.meta.hostHeader !== undefined) {
+            req.headers['host'] = req.meta.hostHeader;
+        }
     };
 
     var getRemoteAddress = function (req) {
@@ -356,6 +359,7 @@ Worker.prototype.runServer = function (config) {
                     backendId: backend.id,
                     backendLen: backend.len,
                     frontend: backend.frontend,
+                    hostHeader: backend.hostHeader,
                     virtualHost: backend.virtualHost,
                     backendUrl: backend.href
                 };
@@ -448,14 +452,14 @@ Worker.prototype.runServer = function (config) {
 
     // Ipv4
     if (config.address) {
-        var length = config.address.length, 
+        var length = config.address.length,
                      address = null;
         for (var i = 0; i < length; i++) {
             var ipv4HttpServer = http.createServer(httpRequestHandler);
             ipv4HttpServer.on('connection', tcpConnectionHandler);
             ipv4HttpServer.on('upgrade', wsRequestHandler);
             ipv4HttpServer.listen(config.port, config.address[i]);
-            
+
             monitor.addServer(ipv4HttpServer);
         }
     } else {
@@ -463,28 +467,28 @@ Worker.prototype.runServer = function (config) {
          ipv4HttpServer.on('connection', tcpConnectionHandler);
          ipv4HttpServer.on('upgrade', wsRequestHandler);
          ipv4HttpServer.listen(config.port);
-         
+
          monitor.addServer(ipv4HttpServer);
     }
 
     // Ipv6
     if (config.address6) {
-        var length = config.address6.length, 
+        var length = config.address6.length,
                      address6 = null;
         for (var i = 0; i < length; i++) {
             var ipv6HttpServer = http.createServer(httpRequestHandler);
             ipv6HttpServer.on('connection', tcpConnectionHandler);
             ipv6HttpServer.on('upgrade', wsRequestHandler);
             ipv6HttpServer.listen(config.port, config.address6[i]);
-            
+
             monitor.addServer(ipv6HttpServer);
-        }        
+        }
     } else {
         var ipv6HttpServer = http.createServer(httpRequestHandler);
         ipv6HttpServer.on('connection', tcpConnectionHandler);
         ipv6HttpServer.on('upgrade', wsRequestHandler);
         ipv6HttpServer.listen(config.port, '::1');
-        
+
         monitor.addServer(ipv6HttpServer);
     }
 
@@ -493,17 +497,17 @@ Worker.prototype.runServer = function (config) {
         var options = config.https;
         options.key = fs.readFileSync(options.key, 'utf8');
         options.cert = fs.readFileSync(options.cert, 'utf8');
-        
+
         //https ipv4
         if (config.address) {
-            var length = config.address.length, 
+            var length = config.address.length,
                          address = null;
             for (var i = 0; i < length; i++) {
                 var ipv4HttpsServer = https.createServer(options, httpRequestHandler);
                 ipv4HttpsServer.on('connection', tcpConnectionHandler);
                 ipv4HttpsServer.on('upgrade', wsRequestHandler);
                 ipv4HttpsServer.listen(config.https.port, config.address[i]);
-            
+
                 monitor.addServer(ipv4HttpsServer);
             }
         } else {
@@ -514,25 +518,25 @@ Worker.prototype.runServer = function (config) {
 
             monitor.addServer(ipv4HttpsServer);
         }
-        
+
         //https ipv6
         if (config.address6) {
-            var length = config.address6.length, 
+            var length = config.address6.length,
                          address6 = null;
             for (var i = 0; i < length; i++) {
                 var ipv6HttpsServer = https.createServer(options, httpRequestHandler);
                 ipv6HttpsServer.on('connection', tcpConnectionHandler);
                 ipv6HttpsServer.on('upgrade', wsRequestHandler);
                 ipv6HttpsServer.listen(config.https.port, config.address6[i]);
-            
+
                 monitor.addServer(ipv6HttpsServer);
-            }        
+            }
         } else {
             var ipv6HttpsServer = https.createServer(options, httpRequestHandler);
             ipv6HttpsServer.on('connection', tcpConnectionHandler);
             ipv6HttpsServer.on('upgrade', wsRequestHandler);
             ipv6HttpsServer.listen(config.https.port, '::1');
-            
+
             monitor.addServer(ipv6HttpsServer);
         }
     }


### PR DESCRIPTION
Work towards resolving the rolodex-on-heroku CSRF issue, as well as a fix to get smartling proxying capabilities.

Tagging @doomspork for review, @paultannenbaum / @bdoms for javascript chops (if you can think of more efficient ways of accomplishing these things, lemme know).

Some demonstration of how it works... in particular this allows us to front any domain with our proxy system:

```
aaron-mba:rtopia aaron$ curl -i 'http://localhost:8081/services/products/1395?store=105&currency=CAD&from=2014-04-18' -H 'Host: fr-ca.liftopia.tv' -H 'x-debug: true'
HTTP/1.1 200 OK
cache-control: max-age=0, private, must-revalidate
content-type: application/json; charset=utf-8
date: Wed, 19 Feb 2014 01:44:54 GMT
etag: "72242b31481fe3ba9757a84205593253"
server: nginx
set-cookie: AWSELB=FF41C189107B39B41E95FFD3EF2EB900C9873E5E0C19119A5D6191D733FB2E865696138E3225B590DC61AA869D50EA658F738FF5E0A96449F51D144688DEBADF963822FC77;PATH=/;MAX-AGE=120
status: 200 OK
vary: Accept-Encoding
x-request-id: 77a67d917f7b54aef2e8d17821a46395
x-runtime: 0.273540
x-server: Smartling
x-ua-compatible: IE=Edge,chrome=1
transfer-encoding: chunked
connection: Close
x-debug-version-hipache: 0.2.5
x-debug-backend-url: http://liftopia-tv.sl.smartling.com:80/
x-debug-backend-id: 0
x-debug-vhost: fr-ca.liftopia.tv
x-debug-frontend-key: fr-ca.liftopia.tv
x-debug-time-total: 692
x-debug-time-backend: 691

{<content>}
```
